### PR TITLE
Support for OpenJDK 7

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+phpstorm (7.1.3-2) precise; urgency=medium
+
+  * Extend JDK dependencies.
+
+ -- Jérôme Parmentier <jerome.parmentier@acensi.fr>  Thu, 03 Jul 2014 11:09:54 +0200
+
 phpstorm (7.1.3-1) precise; urgency=low
 
   * New upstream version

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.jetbrains.com/phpstorm/
 
 Package: phpstorm
 Architecture: all
-Depends: oracle-java7-installer | oracle-java8-installer | oracle-java6-installer | sun-java7-jdk | sun-java8-jdk | sun-java6-jdk
+Depends: openjdk-7-jre | oracle-java7-installer | oracle-java8-installer | oracle-java6-installer | sun-java7-jdk | sun-java8-jdk | sun-java6-jdk
 Description: PhpStorm is a lightweight and smart PHP IDE focused on developer productivity 
  that deeply understands your code, provides smart code completion, quick 
  navigation and on-the-fly error checking. It is always ready to help you 


### PR DESCRIPTION
According to http://www.jetbrains.com/phpstorm/download/#linux, PHPStorm now support OpenJDK 7.
