### PR TITLE
Add phpstorm's java VM options to debian conffiles

### DIFF
--- a/debian/conffiles
+++ b/debian/conffiles
@@ -1,0 +1,2 @@
+/opt/PhpStorm/bin/phpstorm.vmoptions
+/opt/PhpStorm/bin/phpstorm64.vmoptions


### PR DESCRIPTION
This prevents issues with a user's custom Java VM options, e.g. "-Xmx2048m" for more heap space, being overwritten every time the deb is built for a new upstream version. Dpkg will now use its normal configuration file resolution on these files and avoid overwriting them if a user has made changes.