### PR TITLE
Added openjdk-8-jre as dependency for compatibility with debian testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,24 @@ Build scripts to easily create a `.deb` package for PhpStorm.
 Dependencies
 ------------
 
-You will need the `devscripts` and the `debhelper` packages installed in order to build the PhpStorm `.deb` file:
+You will need the `devscripts` `debhelper` `php` and `php-curl` packages installed in order to build the PhpStorm `.deb` file:
 
 ```sh
-apt-get install devscripts debhelper
+apt-get install devscripts debhelper php php-curl
 ```
 
+Build (Automatic)
+----------------
+* Run the `download_latest.php` file
+```sh
+php download_latest.php
+```
 
-Building
---------
+This will execute all steps described below.
+
+
+Building (Manuallly)
+--------------------
 
 * Download the `.tar.gz` file from [PhpStorm's download page](https://www.jetbrains.com/phpstorm/download/index.html) and place it in the root directory of this repo.
 

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: http://www.jetbrains.com/phpstorm/
 
 Package: phpstorm
 Architecture: all
-Depends: openjdk-7-jre | oracle-java7-installer | oracle-java8-installer | oracle-java6-installer | sun-java7-jdk | sun-java8-jdk | sun-java6-jdk, libxcursor1, libxfixes3, libxi6, libxrender1, libxtst6
+Depends: openjdk-7-jre | openjdk-8-jre | oracle-java7-installer | oracle-java8-installer | oracle-java6-installer | sun-java7-jdk | sun-java8-jdk | sun-java6-jdk, libxcursor1, libxfixes3, libxi6, libxrender1, libxtst6
 Recommends: fonts-dejavu-core, fonts-freefont-otf, ttf-bitstream-vera, fonts-cantarell, fonts-droid, ttf-mscorefonts-installer
 Description: PhpStorm is a lightweight and smart PHP IDE focused on developer productivity 
  that deeply understands your code, provides smart code completion, quick 

--- a/download_latest.php
+++ b/download_latest.php
@@ -1,0 +1,67 @@
+#!/usr/bin/env php
+<?php
+ $dir = dirname(__FILE__);
+
+ echo "Cleaning up old installs\n";
+ array_map('unlink', glob("*.tar.gz"));
+ array_map('unlink', glob("*.sha256"));
+
+ echo "Downloading new version\n";
+ $url = "https://data.services.jetbrains.com/products/releases?code=PS&latest=true";
+ $result = curlDownload($url);
+
+$data = json_decode($result, true);
+$link = $data["PS"][0]["downloads"]["linux"]["link"];
+$md5sum = $data["PS"][0]["downloads"]["linux"]["checksumLink"];
+
+echo "Downloading $link\n";
+
+$filename = basename($link);
+$checksumName = basename($md5sum);
+
+curlDownload($link, $dir."/".$filename);
+echo "Downloading $md5sum\n";
+curlDownload($md5sum, $dir."/".$checksumName);
+
+echo "Verifying checksum";
+$exitcode = "";
+$output = "";
+exec ("sha256sum -c $dir/$checksumName", $output, $exitcode);
+
+if ((int)$exitcode !== 0)
+{
+  echo "Checksum failed!";
+  exit;
+}
+
+shell_exec($dir."/update.sh");
+echo "Download and update complete. Execute the following commands to build and update the new php version\n";
+
+echo "Building latest version.. \n";
+chdir ($dir);
+exec("debuild -us -uc -b");
+
+$debname = str_replace("-","_",strtolower(basename($filename,".tar.gz"))."_all.deb");
+echo "Build complete. Install the new version by using \n";
+echo "sudo dpkg -i ../$debname";
+
+function curlDownload($url, $destination = null)
+{
+ $ch = curl_init();
+ //curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+ curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+ curl_setopt($ch, CURLOPT_URL, $url);
+ curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+ $result=curl_exec($ch);
+ 
+ // Closing
+ curl_close($ch);
+ if ($destination)
+ {
+   $file = fopen($destination, "w+");
+   fputs($file, $result);
+   fclose($file);
+ }
+
+ return $result;
+}


### PR DESCRIPTION
With a recent upgrade of debian testing phpstorm got deleted because the other options for java runtimes were not available. Adding the available openjdk-8-jre as a possible dependency and rebuilding solved the problem.
