### PR TITLE
Add platform properties to debian conffiles

### DIFF
--- a/debian/conffiles
+++ b/debian/conffiles
@@ -1,2 +1,3 @@
+/opt/PhpStorm/bin/idea.properties
 /opt/PhpStorm/bin/phpstorm.vmoptions
 /opt/PhpStorm/bin/phpstorm64.vmoptions


### PR DESCRIPTION
As well as the JVM options, [platform properties](https://intellij-support.jetbrains.com/hc/en-us/articles/206544869-Configuring-JVM-options-and-platform-properties) may be customised in the application directory rather than the user's configuration directory.