### PR TITLE
Decode file and line data from url

### DIFF
--- a/phpstorm.php
+++ b/phpstorm.php
@@ -5,8 +5,8 @@ file_put_contents('/tmp/phpstorm.commandline', $argv[1]);
 
 if ($argc === 2 && preg_match('(^phpstorm:\/\/open\?file=(.*)\&line=([0-9]+)\/?$)', $argv[1], $matches)) {
 
-	$fileName = escapeshellarg($matches[1]);
-	$lineNumber = escapeshellarg($matches[2]);
+	$fileName = escapeshellarg(urldecode($matches[1]));
+	$lineNumber = escapeshellarg(urldecode($matches[2]));
 
 	system("/opt/PhpStorm/bin/phpstorm.sh --line " . $lineNumber . " " . $fileName);
 } else {


### PR DESCRIPTION
PhpStorm will fail to open a file path that has been URL-encoded. Since the path information is coming from an URL in this case, we should decode it first.