### PR TITLE
Use native launcher

### DIFF
--- a/phpstorm.php
+++ b/phpstorm.php
@@ -8,12 +8,12 @@ if ($argc === 2 && preg_match('(^phpstorm:\/\/open\?file=(.*)\&line=([0-9]+)\/?$
 	$fileName = escapeshellarg(urldecode($matches[1]));
 	$lineNumber = escapeshellarg(urldecode($matches[2]));
 
-	system("/opt/PhpStorm/bin/phpstorm.sh --line " . $lineNumber . " " . $fileName);
+	system("/opt/PhpStorm/bin/phpstorm --line " . $lineNumber . " " . $fileName);
 } else {
 
 	array_shift($argv);
 	$cmdLine = implode(" ", array_map('escapeshellarg', $argv));
 
-	system("/opt/PhpStorm/bin/phpstorm.sh " . $cmdLine);
+	system("/opt/PhpStorm/bin/phpstorm " . $cmdLine);
 }
 


### PR DESCRIPTION
PhpStorm advises to "Switch to a native launcher" if launched from a script like `phpstorm.sh`, advising to use the native binary instead.

Reference: [How to handle "Switch to a native launcher" notification](https://youtrack.jetbrains.com/articles/SUPPORT-A-56/How-to-handle-Switch-to-a-native-launcher-notification) (JetBrains YouTrack).